### PR TITLE
Support filter proxy node from proxy select box via typing text

### DIFF
--- a/lmcache_frontend/static/css/style.css
+++ b/lmcache_frontend/static/css/style.css
@@ -83,3 +83,59 @@ pre {
     word-wrap: break-word;
     overflow-wrap: break-word;
 }
+
+/* Proxy search dropdown styles */
+#proxySearchInput {
+    cursor: pointer;
+}
+
+#proxyDropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1000;
+    display: none;
+    min-width: 100%;
+    padding: 0.5rem 0;
+    margin: 0.125rem 0 0;
+    font-size: 1rem;
+    color: #212529;
+    text-align: left;
+    list-style: none;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid rgba(0,0,0,.15);
+    border-radius: 0.25rem;
+    box-shadow: 0 0.5rem 1rem rgba(0,0,0,.175);
+}
+
+#proxyDropdown.show {
+    display: block;
+}
+
+#proxyDropdown .dropdown-item {
+    display: block;
+    width: 100%;
+    padding: 0.25rem 1rem;
+    clear: both;
+    font-weight: 400;
+    color: #212529;
+    text-align: inherit;
+    text-decoration: none;
+    white-space: nowrap;
+    background-color: transparent;
+    border: 0;
+    cursor: pointer;
+}
+
+#proxyDropdown .dropdown-item:hover,
+#proxyDropdown .dropdown-item:focus {
+    color: #1e2125;
+    background-color: #e9ecef;
+}
+
+#proxyDropdown .dropdown-item.disabled {
+    color: #6c757d;
+    pointer-events: none;
+    background-color: transparent;
+}

--- a/lmcache_frontend/static/index.html
+++ b/lmcache_frontend/static/index.html
@@ -16,9 +16,15 @@
                 <div class="col-md-6">
                     <div class="row g-2">
                         <div class="col-md-6">
-                            <select id="proxySelector" class="form-select">
-                                <option value="">-- Select Proxy --</option>
-                            </select>
+                            <div class="position-relative">
+                                <input type="text" id="proxySearchInput" class="form-control" placeholder="Search and select proxy..." autocomplete="off">
+                                <select id="proxySelector" class="form-select d-none">
+                                    <option value="">-- Select Proxy --</option>
+                                </select>
+                                <div id="proxyDropdown" class="dropdown-menu" style="max-height: 300px; overflow-y: auto; width: 100%;">
+                                    <!-- Proxy options will be populated here -->
+                                </div>
+                            </div>
                         </div>
                         <div class="col-md-6">
                             <select id="targetSelector" class="form-select" disabled>

--- a/lmcache_frontend/static/js/app.js
+++ b/lmcache_frontend/static/js/app.js
@@ -2,12 +2,34 @@
 let currentNode = null;
 let currentProxy = null;
 let proxyNodes = {};
+let allProxies = []; // Store all proxies for filtering
+
 // Initialize after DOM is loaded
 window.addEventListener('DOMContentLoaded', () => {
     // Initialize proxy selector
     loadProxies();
 
-    // Proxy selection event
+    // Proxy search input event
+    const proxySearchInput = document.getElementById('proxySearchInput');
+    const proxyDropdown = document.getElementById('proxyDropdown');
+    
+    proxySearchInput.addEventListener('focus', () => {
+        filterProxies();
+        proxyDropdown.classList.add('show');
+    });
+    
+    proxySearchInput.addEventListener('input', () => {
+        filterProxies();
+    });
+    
+    // Close dropdown when clicking outside
+    document.addEventListener('click', (e) => {
+        if (!proxySearchInput.contains(e.target) && !proxyDropdown.contains(e.target)) {
+            proxyDropdown.classList.remove('show');
+        }
+    });
+
+    // Proxy selection event (kept for compatibility)
     document.getElementById('proxySelector').addEventListener('change', (e) => {
         const proxyName = e.target.value;
         if (proxyName) {
@@ -95,6 +117,7 @@ async function loadProxies() {
         selector.innerHTML = '<option value="">-- Select Proxy --</option>';
 
         proxyNodes = {};
+        allProxies = [];
 
         data.proxies.forEach(proxy => {
             const option = document.createElement('option');
@@ -103,10 +126,70 @@ async function loadProxies() {
             selector.appendChild(option);
 
             proxyNodes[proxy.name] = proxy;
+            allProxies.push(proxy);
         });
+        
+        // Initialize dropdown with all proxies
+        filterProxies();
     } catch (error) {
         console.error('Failed to load proxies:', error);
     }
+}
+
+// Filter proxies based on search input
+function filterProxies() {
+    const searchInput = document.getElementById('proxySearchInput');
+    const dropdown = document.getElementById('proxyDropdown');
+    const searchTerm = searchInput.value.toLowerCase();
+    
+    dropdown.innerHTML = '';
+    
+    const filteredProxies = allProxies.filter(proxy => {
+        const proxyText = `${proxy.name} (${proxy.host}:${proxy.port})`.toLowerCase();
+        return proxyText.includes(searchTerm);
+    });
+    
+    if (filteredProxies.length === 0) {
+        const noResultItem = document.createElement('div');
+        noResultItem.className = 'dropdown-item disabled';
+        noResultItem.textContent = 'No matching proxies found';
+        dropdown.appendChild(noResultItem);
+    } else {
+        filteredProxies.forEach(proxy => {
+            const item = document.createElement('a');
+            item.className = 'dropdown-item';
+            item.href = '#';
+            item.textContent = `${proxy.name} (${proxy.host}:${proxy.port})`;
+            item.dataset.proxyName = proxy.name;
+            
+            item.addEventListener('click', (e) => {
+                e.preventDefault();
+                selectProxy(proxy);
+            });
+            
+            dropdown.appendChild(item);
+        });
+    }
+}
+
+// Select a proxy
+function selectProxy(proxy) {
+    const searchInput = document.getElementById('proxySearchInput');
+    const dropdown = document.getElementById('proxyDropdown');
+    const selector = document.getElementById('proxySelector');
+    
+    // Update search input display
+    searchInput.value = `${proxy.name} (${proxy.host}:${proxy.port})`;
+    
+    // Update hidden selector
+    selector.value = proxy.name;
+    
+    // Close dropdown
+    dropdown.classList.remove('show');
+    
+    // Trigger proxy selection
+    currentProxy = proxyNodes[proxy.name];
+    loadTargetNodes(proxy.name);
 }
 
 // Load target nodes for selected proxy
@@ -738,22 +821,26 @@ async function filterNodesByEnv() {
 
     try {
         // Show loading indicator
+        const proxySearchInput = document.getElementById('proxySearchInput');
         const proxySelector = document.getElementById('proxySelector');
         const targetSelector = document.getElementById('targetSelector');
-        proxySelector.innerHTML = '<option value="">Filtering proxies...</option>';
-        proxySelector.disabled = true;
+        const proxyDropdown = document.getElementById('proxyDropdown');
+        
+        proxySearchInput.value = 'Filtering proxies...';
+        proxySearchInput.disabled = true;
+        proxyDropdown.classList.remove('show');
         targetSelector.innerHTML = '<option value="">-- Select Target --</option>';
         targetSelector.disabled = true;
 
         // Get all proxies
         const response = await fetch('/api/proxies');
         const data = await response.json();
-        const allProxies = data.proxies;
+        const fetchedProxies = data.proxies;
 
         // Check each proxy's nodes for matching environment variables
         const matchingProxies = new Map(); // Map<proxyName, matchingNodes[]>
         
-        for (const proxy of allProxies) {
+        for (const proxy of fetchedProxies) {
             try {
                 // Get nodes for this proxy
                 const nodesResponse = await fetch(`/api/proxies/${proxy.name}/nodes`);
@@ -822,39 +909,34 @@ async function filterNodesByEnv() {
         }
 
         // Update proxy selector with filtered proxies
-        proxySelector.innerHTML = '<option value="">-- Select Proxy --</option>';
-        proxySelector.disabled = false;
+        proxySearchInput.value = '';
+        proxySearchInput.disabled = false;
 
         if (matchingProxies.size === 0) {
             const filterDesc = filterValue === null ? filterKey : `${filterKey}=${filterValue}`;
             alert(`No nodes found with ${filterDesc}`);
+            // Restore original proxy list
+            loadProxies();
         } else {
+            // Update global allProxies with filtered results
+            allProxies = [];
             let totalNodes = 0;
+            const proxyNodeMap = new Map(); // Store matching nodes for each proxy
+            
             matchingProxies.forEach((nodes, proxyName) => {
-                const proxy = allProxies.find(p => p.name === proxyName);
+                const proxy = fetchedProxies.find(p => p.name === proxyName);
                 if (proxy) {
-                    const option = document.createElement('option');
-                    option.value = proxyName;
-                    option.textContent = `${proxy.name} (${nodes.length} matching nodes)`;
-                    option.dataset.matchingNodes = JSON.stringify(nodes);
-                    proxySelector.appendChild(option);
+                    allProxies.push(proxy);
+                    proxyNodeMap.set(proxyName, nodes);
                     totalNodes += nodes.length;
                 }
             });
             
+            // Rebuild filtered proxy list
+            filterProxies();
+            
             const filterDesc = filterValue === null ? filterKey : `${filterKey}=${filterValue}`;
             alert(`Found ${matchingProxies.size} proxy(ies) with ${totalNodes} matching node(s) for ${filterDesc}`);
-            
-            // Add event listener to load filtered nodes when proxy is selected
-            proxySelector.addEventListener('change', function handleFilteredProxyChange(e) {
-                const selectedOption = e.target.selectedOptions[0];
-                if (selectedOption && selectedOption.dataset.matchingNodes) {
-                    const nodes = JSON.parse(selectedOption.dataset.matchingNodes);
-                    loadTargetNodes(e.target.value, nodes);
-                    // Remove this listener after first use
-                    proxySelector.removeEventListener('change', handleFilteredProxyChange);
-                }
-            }, { once: true });
         }
     } catch (error) {
         console.error('Failed to filter nodes:', error);


### PR DESCRIPTION
Without this PR, if there are lots of item in the proxy list box, it is hard to scan and find the target proxy node one by one, with this PR, we can type a query text to filter the target proxy node easily.

<img width="982" height="814" alt="Clipboard_Screenshot_1767180386" src="https://github.com/user-attachments/assets/050abad5-6153-4af2-aba6-e0a70bb1ccd1" />
